### PR TITLE
Fix readme script; create readme for freelance jobs

### DIFF
--- a/packages/freelance-jobs/README.md
+++ b/packages/freelance-jobs/README.md
@@ -1,3 +1,83 @@
 # Freelance Jobs Adapter
 
-TODO
+![1.0.1](https://img.shields.io/github/package-json/v/linkpoolio/adapters?filename=packages/freelance-jobs/package.json)
+
+An adapter to find freelance jobs published
+
+This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
+
+## Environment Variables
+
+| Required? |     Name     |         Description         |  Type  | Options | Default |
+| :-------: | :----------: | :-------------------------: | :----: | :-----: | :-----: |
+|           |   API_KEY    | The data provider's API key | string |         |         |
+|           | API_PROVIDER |      The data provider      | string |         |         |
+
+---
+
+## Input Parameters
+
+Every EA supports base input parameters from [this list](../../core/bootstrap#base-input-parameters)
+
+| Required? |   Name   |     Description     |  Type  |        Options         | Default |
+| :-------: | :------: | :-----------------: | :----: | :--------------------: | :-----: |
+|           | endpoint | The endpoint to use | string | [jobs](#jobs-endpoint) |         |
+
+## Jobs Endpoint
+
+This endpoint returns a single job.
+
+`jobs` is the only supported name for this endpoint.
+
+### Input Params
+
+| Required? |  Name  | Aliases |              Description               |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :----: | :-----: | :------------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | method |         |      The endpoint request method       | string |  `get`  |         |            |                |
+|           | parse  |         | Properties to return (comma separated) | string |         |         |            |                |
+|    ✅     | jobId  |         |           The job identifier           | number |         |         |            |                |
+
+### Example
+
+Request:
+
+```json
+{
+  "id": 1,
+  "data": {
+    "endpoint": "jobs",
+    "method": "get",
+    "jobId": 1
+  },
+  "debug": {
+    "cacheKey": "BSauWl83Z0mfHs6m3b+nJIKsaS4="
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "jobRunID": 1,
+  "data": {
+    "id": 1,
+    "employer": {
+      "address": "0x6613A30A0D7F4011Cb569ca89f5a107cF9A542f2"
+    },
+    "freelancer": {
+      "address": "0xbDf9CD30F6201B02F48d94878a86cf9B375f6344"
+    },
+    "payment": {
+      "amount": "10000000000000000000",
+      "currency": "LANC",
+      "units": "wei"
+    }
+  },
+  "statusCode": 200
+}
+```
+
+---
+
+MIT License

--- a/packages/scripts/src/generate-readme/generator.ts
+++ b/packages/scripts/src/generate-readme/generator.ts
@@ -97,9 +97,9 @@ export class ReadmeGenerator {
     this.defaultEndpoint = configFile.DEFAULT_ENDPOINT
     this.defaultBaseUrl = configFile.DEFAULT_BASE_URL || configFile.DEFAULT_WS_API_ENDPOINT
 
-    if (this.verbose) console.log(`${this.adapterPath}: Importing src/endpoint/index.ts`)
+    if (this.verbose) console.log(`${this.adapterPath}: Importing src/controllers/index.ts`)
 
-    const endpointPath = checkFilePaths([this.adapterPath + 'src/endpoint/index.ts'])
+    const endpointPath = checkFilePaths([this.adapterPath + 'src/controllers/index.ts'])
     this.endpointDetails = await require(localPathToRoot + endpointPath)
   }
 

--- a/packages/scripts/src/generate-readme/index.ts
+++ b/packages/scripts/src/generate-readme/index.ts
@@ -92,7 +92,6 @@ export async function main(): Promise<void | string> {
       return map
     }, {})
     adapters = adapters.filter((a) => !adapterInBlacklist[a.name])
-
     // Collect new README versions
     const readmeQueue = await Promise.all(
       adapters.map(async (adapter: Adapter) => {


### PR DESCRIPTION
Fixes readme script (change path from `endpoint` to `controllers`)
Run readme script for freelance-jobs `yarn generate:readme freelance-jobs`